### PR TITLE
fix: re-enable jsdoc checks

### DIFF
--- a/lib/eslint.mjs
+++ b/lib/eslint.mjs
@@ -3,6 +3,7 @@ import formatjs from 'eslint-plugin-formatjs'
 import html from 'eslint-plugin-html'
 import htmlSettings from 'eslint-plugin-html/src/settings.js'
 import importPlugin from 'eslint-plugin-import'
+import jsdoc from 'eslint-plugin-jsdoc'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
 import markdown from 'eslint-plugin-markdown'
 import react from 'eslint-plugin-react'
@@ -129,6 +130,29 @@ const makeEslintConfig = ({ tsconfigRootDir, globals: globalsIn } = {}) => {
       plugins: importPlugin.flatConfigs.recommended.plugins,
       rules: {
         'import/no-duplicates': 'error', // Forbid duplicate imports
+      },
+    },
+    // eslint-plugin-jsdoc
+    jsdoc.configs['flat/recommended-error'],
+    {
+      files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+      extends: [jsdoc.configs['flat/recommended-typescript-error']],
+    },
+    {
+      rules: {
+        // If JSDoc comments are present, they must be informative (non-trivial).
+        // For example, the description "The foo." on a variable called "foo" is not informative.
+        // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/informative-docs.md
+        'jsdoc/informative-docs': ['error'],
+
+        // Require JSDoc comments on public / exported items.
+        // https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-jsdoc.md
+        'jsdoc/require-jsdoc': [
+          'error',
+          {
+            publicOnly: true,
+          },
+        ],
       },
     },
     // eslint-plugin-jsx-a11y

--- a/lib/prettier.mjs
+++ b/lib/prettier.mjs
@@ -23,8 +23,7 @@ const prettierConfig = {
 }
 
 /**
- * Make a Prettier configuration for Scratch style.
- * @returns {import("prettier").Config}
+ * @returns {import("prettier").Config} A Prettier configuration for Scratch style.
  */
 const makePrettierConfig = () => prettierConfig
 


### PR DESCRIPTION
### Resolves

- Resolves scratchfoundation/eslint-config-scratch#20 (again)

### Proposed Changes

Add `eslint-plugin-jsdoc` to the new configuration. Specifically, the plugin's recommended configuration is enabled generally and then overridden by the plugin's recommended TypeScript configuration for TypeScript files.

### Reason for Changes

I forgot to add `eslint-plugin-jsdoc` when creating our new configuration, even though it's present in the legacy configurations. This change re-adds the plugin and configures it for better interaction with TypeScript.

### Test Coverage

Tested locally on this repository. I also created some temporary TypeScript files to test those rules.